### PR TITLE
Update libv8 to a version that works with Clang 8.00 (MacOS 10.12)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ group :assets do
   gem 'coffee-rails',   '~> 3.2.1'
   gem 'bootstrap-sass', '2.3.2.1'
   gem 'therubyracer'
-  gem 'libv8', '=3.16.14.7'  # dep of therubyracer fails to compile (bad C code) in '3.16.14.9'
+  gem 'libv8', '=3.16.14.17' # dep of therubyracer
   gem 'uglifier', '>= 1.0.3'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.4.1)
       launchy (~> 2.2)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.17)
     logger (1.2.8)
     looksee (3.1.0)
     lyber-utils (0.1.2)
@@ -496,7 +496,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   letter_opener
-  libv8 (= 3.16.14.7)
+  libv8 (= 3.16.14.17)
   looksee
   lyberteam-capistrano-devel
   moab-versioning (~> 1.4.0)
@@ -518,3 +518,6 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   validates_email_format_of
   whenever (~> 0.9)
+
+BUNDLED WITH
+   1.14.5


### PR DESCRIPTION
Fixes #33 