### PR TITLE
ensure not all contributors are blank

### DIFF
--- a/app/models/hydrus/item.rb
+++ b/app/models/hydrus/item.rb
@@ -19,6 +19,7 @@ class Hydrus::Item < Hydrus::GenericObject
   validate  :enforce_collection_is_open, :on => :create
   
   validates :contributors, :at_least_one => true,  :if => :should_validate
+  validate  :contributors_not_all_blank,           :if => :should_validate
   validates :files, :at_least_one => true,         :if => :should_validate
   validate  :must_accept_terms_of_deposit,         :if => :should_validate
   validate  :must_review_release_settings,         :if => :should_validate
@@ -398,6 +399,13 @@ class Hydrus::Item < Hydrus::GenericObject
     return true if c && c.is_open
     errors.add(:collection, "must be open to have new items added")
     return false
+  end
+
+  # you must have at least one non-blank contributor
+  def contributors_not_all_blank
+    if (contributors.all? {|contributor| contributor.name.blank?})
+      errors.add(:contributors, "must be entered")
+    end
   end
 
   # the user must accept the terms of deposit to publish

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,7 +41,7 @@ end
 Dor::Config.configure do
 
   purl do
-    base_url 'https://purl-dev.stanford.edu/'
+    base_url 'https://purl-test.stanford.edu/'
   end
 
   hydrus do

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -22,7 +22,6 @@ task :ci => ['jetty:clean', 'jetty:config'] do
     ENV['COVERAGE'] = original_coverage || 'false'
   end
   raise "TEST FAILURES: #{error}" if error
-  Rake::Task["doc:reapp"].invoke
 end
 
 desc "Run only unit tests with coverage report, assumes jetty is running already and no fixture refreshes"

--- a/spec/models/hydrus/item_spec.rb
+++ b/spec/models/hydrus/item_spec.rb
@@ -673,6 +673,7 @@ describe Hydrus::Item, :type => :model do
       allow(@hi).to receive(:reviewed_release_settings).and_return(true)
       @exp.each { |e| allow(@hi).to receive(e).and_return(dru) unless e==:contact }
       allow(@hi).to receive(:contact).and_return('test@test.com') # we need a valid email address
+      allow(@hi).to receive(:contributors).and_return([Hydrus::Contributor.new(:name=>'Some, person')]) # need at least one non-blank contributor
       allow(@hi).to receive(:keywords).and_return(%w(aaa bbb))
       allow(@hi).to receive(:dates).and_return({:date_created => '2011'})
       allow(@hi).to receive(:date_created).and_return('2011')


### PR DESCRIPTION
- fixes #42 and adds a test
- remove auto rebuilding of rdoc each time rake ci is run (this doesn't work now anyway)
- change purl-dev to purl-test in development.rb config (purl-dev doesn't exist anymore and causes an exception in development when you try to edit an item)