### PR TITLE
Don't expect Pacific time when testing.

### DIFF
--- a/spec/models/hy_time_spec.rb
+++ b/spec/models/hy_time_spec.rb
@@ -60,17 +60,24 @@ describe HyTime, :type => :model do
       expect(HyTime.formatted('')).to  eq('')
     end
 
-    it "should convert to UTC if :from_localzone is true" do
-      dt = '2000-01-02'
-      tests = {
-        false => '2000-01-02T00:00:00Z',
-        true  => '2000-01-02T0[78]:00:00Z',  # 7 or 8, so test passes during DST.
-      }
-      tests.each do |fltz, exp|
-        expect(HyTime.formatted(dt, :from_localzone => fltz)).to match(/\A#{exp}\z/)
+    context "when :from_localzone is set" do
+      let(:dt) { '2000-01-02' }
+      before do
+        # Force Pacific time
+        allow(DateTime).to receive(:local_offset).and_return((-8 * 60 * 60).to_r/86400)
+      end
+      subject { HyTime.formatted(dt, :from_localzone => fltz) }
+
+      context "when false" do
+        let(:fltz) { false }
+        it { is_expected.to eq('2000-01-02T00:00:00Z') }
+      end
+
+      context "when true" do
+        let(:fltz) { true }
+        it { is_expected.to eq('2000-01-02T08:00:00Z') }
       end
     end
-
   end
 
   it "is_well_formed_datetime()" do

--- a/spec/models/hydrus/item_spec.rb
+++ b/spec/models/hydrus/item_spec.rb
@@ -369,6 +369,8 @@ describe Hydrus::Item, :type => :model do
 
     before(:each) do
       @edate = '2012-02-28T08:00:00Z'
+      # This enables the tests to run in a timezone other than Pacific.
+      allow(HyTime).to receive(:datetime).with("2012-02-28", :from_localzone => true).and_return(@edate)
       # XML snippets for various <access> nodes.
       ed       = "<embargoReleaseDate>#{@edate}</embargoReleaseDate><none/>"
 
@@ -451,11 +453,14 @@ describe Hydrus::Item, :type => :model do
       end
 
       describe "setter: with valid date" do
+        let(:rd_dt) { "2012-08-30T08:00:00Z" }
+        before do
+          # This enables the tests to run in a timezone other than Pacific.
+          allow(HyTime).to receive(:datetime).with("2012-08-30", :from_localzone => true).and_return(rd_dt)
+        end
 
         it "store date in UTC in both embargoMD and rightsMD" do
-          rd = '2012-08-30'
-          rd_dt = HyTime.datetime("#{rd}T08:00:00Z")
-          @hi.embargo_date = rd
+          @hi.embargo_date = '2012-08-30'
           expect(@hi.embargo_date).to eq(rd_dt)
           expect(@hi.rmd_embargo_release_date).to eq(rd_dt)
           expect(@hi.embargoMetadata.status).to eq('embargoed')


### PR DESCRIPTION
Allows testing for remote workers who aren't in the Pacific Time Zone.