### PR TITLE
remove rememberable from devise to avoid any security issue with v2 o…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,9 @@ class User < ActiveRecord::Base
   include Blacklight::User
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :trackable, :validatable
 
-  attr_accessible :email, :password, :password_confirmation, :remember_me
+  attr_accessible :email, :password, :password_confirmation
 
   # Blacklight uses #to_s on your user class to get
   # a user-displayable login/identifier for the account.

--- a/app/views/sessions/_signin_form.html.erb
+++ b/app/views/sessions/_signin_form.html.erb
@@ -25,10 +25,6 @@
           <%= f.password_field :password, :tabindex => '2' %>
         </fieldset>
         <%= f.submit "Sign in", :class=>"btn signin-submit", :tabindex => '3' %>
-        <fieldset class="remember-me">
-          <%= f.check_box :remember_me, :tabindex => '4' %>
-          <%= f.label :remember_me %>
-        </fieldset>
       </div>
       <div class="webauth">
         <%= link_to("Sign in via WebAuth", webauth_login_path(:referrer => params[:referrer]), :class => 'btn', :tabindex => '5') %>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,7 +44,8 @@ set :linked_dirs, %w{log config/certs tmp/pids tmp/cache tmp/sockets vendor/bund
 
 
 set :bundle_without, %w{development test deployment}.join(' ')
-set :bundle_audit_ignore, %w{CVE-2015-3226}
+set :bundle_audit_ignore, %w{CVE-2015-8314} # Devise issue with rememberable -- instead of upgrading devise from 2 to 3, just disabled remember me token
+                                            # devise is only used in development -- webauth used exclusively in prod anyway
 
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)


### PR DESCRIPTION
…f devise that we use; remove unncessary bundle_audit_ignore now that we have newer version of rails