### PR TITLE
link config/secrets.yml on a deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -31,6 +31,7 @@ set :linked_files, %w(
   config/workflow.yml
   config/ssl_certs.yml
   config/honeybadger.yml
+  config/secrets.yml
 )
 
 # Default value for linked_dirs is []


### PR DESCRIPTION
rails-secrets was added in a previous commit, but the deploy was not
adjusted to link that file.