### PR TITLE
Update capistrano to the latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     byebug (5.0.0)
       columnize (= 0.9.0)
     cancan (1.6.10)
-    capistrano (3.4.0)
+    capistrano (3.4.1)
       i18n
       rake (>= 10.0.0)
       sshkit (~> 1.3)
@@ -424,7 +424,7 @@ GEM
       bootstrap-sass
       rails (>= 3.1.0)
     systemu (2.6.5)
-    term-ansicolor (1.3.2)
+    term-ansicolor (1.6.0)
       tins (~> 1.0)
     test-unit (3.2.5)
       power_assert
@@ -434,7 +434,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (1.4.1)
-    tins (1.5.4)
+    tins (1.15.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)


### PR DESCRIPTION
Previously we were depending on 3.8 features, but we didn't have that
version bundled.

So this worked:

```
cap stage deploy
```

but this would error
```
bundle exec cap stage deploy
```