### PR TITLE
Eager load on dortest

### DIFF
--- a/config/environments/dortest.rb
+++ b/config/environments/dortest.rb
@@ -67,4 +67,6 @@ Hydrus::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  config.eager_load = true
 end


### PR DESCRIPTION
Currently we get this warning
```
$ bundle exec rails c dortest
config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

Loading dortest environment (Rails 4.2.9)
```