### PR TITLE
Pin mysql to ~> 0.4.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,9 @@ group :development, :test do
 end
 
 group :production do
-  gem 'mysql2'
+  # Rails 4.2.10 only supports mysql2 < 0.5
+  # See https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L3
+  gem 'mysql2', '~> 0.4.5'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       nom-xml (~> 0.6.0)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    mysql2 (0.5.0)
+    mysql2 (0.4.10)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -532,7 +532,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   letter_opener
-  mysql2
+  mysql2 (~> 0.4.5)
   net-http-persistent (~> 2.9)
   okcomputer
   pry


### PR DESCRIPTION
This is due to a restriction in rails 4.2.10.
See https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L3