### PR TITLE
Move jetty configuration to the yaml file

### DIFF
--- a/config/jetty.yml
+++ b/config/jetty.yml
@@ -1,5 +1,6 @@
 default:
   jetty_port: 8983
+  startup_wait: 200
   java_opts:
-    - "-XX:MaxPermSize=128m" 
+    - "-XX:MaxPermSize=128m"
     - "-Xmx256m"

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -13,9 +13,7 @@ task ci: [:rubocop, 'jetty:clean', 'jetty:config'] do
 
   require 'jettywrapper'
   jetty_params = Jettywrapper.load_config.merge({
-    jetty_home: File.expand_path(File.dirname(__FILE__) + '/../../jetty'),
-    jetty_port: 8983,
-    startup_wait: 200
+    jetty_home: File.expand_path(File.dirname(__FILE__) + '/../../jetty')
   })
 
   error = nil


### PR DESCRIPTION
This allows us to do `rake jetty:start hydrus:refreshfix` and it won't
try to proceed to the second task before the first is complete.