### PR TITLE
Shibboleth sets the email as the header

### DIFF
--- a/spec/support/feature_sessions.rb
+++ b/spec/support/feature_sessions.rb
@@ -11,7 +11,7 @@ module Features
 
     def sign_in(user = nil, groups: [])
       logout(:user)
-      TestShibbolethHeaders.user = user.sunetid
+      TestShibbolethHeaders.user = user.email
       TestShibbolethHeaders.groups = groups
     end
 


### PR DESCRIPTION
This adjusts our test headers so they do the same