### PR TITLE
Stop indexing workflows on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -48,7 +48,6 @@ namespace :deploy do
       within release_path do
         with rails_env: fetch(:rails_env) do
           rake 'hydrus:cleanup_tmp'
-          rake 'hydrus:index_all_workflows'
         end
       end
     end


### PR DESCRIPTION
This was a workaround for a problem in the indexing system that has
since been resolved