### PR TITLE
Use the hydra_jetty_verison setter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'uglifier', '>= 1.0.3'
 
 group :development, :test do
   gem 'factory_bot_rails'
-  gem 'jettywrapper', '~> 1.4'
+  gem 'jettywrapper', '~> 2.0'
   gem 'sqlite3'
   gem 'rspec-rails', '~> 3.1'
   gem 'capybara', '~> 2.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     haml (4.0.7)
@@ -261,11 +261,12 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     iso-639 (0.2.8)
-    jettywrapper (1.8.3)
+    jettywrapper (2.0.4)
       activesupport (>= 3.0.0)
       childprocess
       i18n
       logger
+      rubyzip (~> 1.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -440,6 +441,7 @@ GEM
       mime-types
       nokogiri
       rest-client
+    rubyzip (1.2.1)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -536,7 +538,7 @@ DEPENDENCIES
   factory_bot_rails
   honeybadger
   hydra-head (~> 6.5)
-  jettywrapper (~> 1.4)
+  jettywrapper (~> 2.0)
   jquery-rails
   launchy
   letter_opener

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,4 +1,4 @@
-ZIP_FILE = 'https://github.com/projecthydra/hydra-jetty/archive/v7.3.1.zip'
+Jettywrapper.hydra_jetty_version = 'v7.0.0'
 
 desc 'Run Continuous Integration Suite (tests, coverage, docs)'
 task ci: [:rubocop, 'jetty:clean', 'jetty:config'] do
@@ -11,9 +11,9 @@ task ci: [:rubocop, 'jetty:clean', 'jetty:config'] do
 
   Rake::Task['db:migrate'].invoke
 
-  require 'jettywrapper'
   jetty_params = Jettywrapper.load_config.merge({
-    jetty_home: File.expand_path(File.dirname(__FILE__) + '/../../jetty')
+    jetty_home: File.expand_path(File.dirname(__FILE__) + '/../../jetty'),
+    startup_wait: 90
   })
 
   error = nil


### PR DESCRIPTION
This avoids a warning:
```
lib/tasks/ci.rake:1: warning: already initialized constant ZIP_FILE
```