### PR TITLE
Update jettywrapper so it doesn't require the logger gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,11 +266,10 @@ GEM
       concurrent-ruby (~> 1.0)
     iso-639 (0.2.8)
     jaro_winkler (1.5.1)
-    jettywrapper (2.0.4)
+    jettywrapper (2.0.5)
       activesupport (>= 3.0.0)
       childprocess
       i18n
-      logger
       rubyzip (~> 1.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
@@ -285,7 +284,6 @@ GEM
     letter_opener (1.6.0)
       launchy (~> 2.2)
     link_header (0.0.8)
-    logger (1.2.8)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)


### PR DESCRIPTION
That gem was yanked from rubygems