### PR TITLE
Use the datastreams hash accessor rather than send

### DIFF
--- a/app/helpers/hydrus_form_helper.rb
+++ b/app/helpers/hydrus_form_helper.rb
@@ -16,7 +16,7 @@ module HydrusFormHelper
   end
 
   def syntax_highlighted_datastream(obj, dsid)
-    xml = Nokogiri.XML(obj.send(dsid).content, &:noblanks)
+    xml = Nokogiri.XML(obj.datastreams[dsid].content, &:noblanks)
     CodeRay::Duo[:xml, :div].highlight(xml).html_safe
   end
 end

--- a/spec/helpers/hydrus_form_helper_spec.rb
+++ b/spec/helpers/hydrus_form_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe HydrusFormHelper, type: :helper do
+RSpec.describe HydrusFormHelper, type: :helper do
   include HydrusFormHelper
 
   describe 'hydrus form label' do
@@ -26,6 +26,17 @@ describe HydrusFormHelper, type: :helper do
     end
     it 'should apply classes passed in the options hash' do
       expect(hydrus_form_value(class: 'my-super cool-class') { "<input type='text' />" }).to have_selector 'div.my-super.cool-class'
+    end
+  end
+
+  describe 'syntax_highlighted_datastream' do
+    subject { syntax_highlighted_datastream(obj, dsid) }
+    let(:obj) { Dor::Item.new }
+
+    context 'when the dsid is RELS-EXT' do
+      let(:dsid) { 'RELS-EXT' }
+
+      it { is_expected.to be_instance_of ActiveSupport::SafeBuffer }
     end
   end
 end


### PR DESCRIPTION
There is no `RELS-EXT` method on the object.

Fixes #243