### PR TITLE
Use dor-services-client for object registration and opening new versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,24 @@ notifications:
   email: false
 
 sudo: required
+
 services:
   - docker
 
 before_install:
-  - docker run -d -p 8984:8983 -v $PWD/solr_conf/conf/:/myconfig solr:7 solr-create -c hydrus-test -d /myconfig
-  - docker run -d -p 8983:8080 suldlss/fcrepo:no-messaging-latest
-  - docker run -d -p 127.0.0.1:3001:3000 suldlss/workflow-server:latest
-  - docker run -d -p 127.0.0.1:3002:3000 suldlss/suri-rails:latest
-  - docker ps -a
+  # Travis's docker-compose is too old to handle v3.6 docker-compose templates.
+  # This code is from Travis's documentation: https://docs.travis-ci.com/user/docker/#using-docker-compose
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - docker-compose up -d
+  - docker-compose ps
+
+env:
+  global:
+    - DOCKER_COMPOSE_VERSION=1.23.1
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 rvm:
   - 2.5.3 # deployed
-
-script: bundle exec rake ci

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,8 @@ gem 'whenever', '~> 0.9'
 
 # Stanford stuff
 gem 'assembly-objectfile', '~> 1.5'
-gem 'dor-services', '~> 5.31', require: false
+gem 'dor-services', '~> 6.1', require: false
+# gem 'dor-services-client', '~> 1.1'
 gem 'rubydora', '~> 2.1'
 gem 'bagit', '~> 0.4'
 gem 'dor-workflow-service'

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'whenever', '~> 0.9'
 # Stanford stuff
 gem 'assembly-objectfile', '~> 1.5'
 gem 'dor-services', '~> 6.1', require: false
-# gem 'dor-services-client', '~> 1.1'
+gem 'dor-services-client', '~> 1.1'
 gem 'rubydora', '~> 2.1'
 gem 'bagit', '~> 0.4'
 gem 'dor-workflow-service'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,11 +165,13 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (5.32.1)
-      active-fedora (>= 7.0, < 9.a)
+    dor-services (6.1.12)
+      active-fedora (>= 8.7.0, < 9)
       activesupport (>= 4.2.10, < 6.0.0)
       confstruct (~> 0.2.7)
+      deprecation (~> 0)
       dor-rights-auth (~> 1.0, >= 1.2.0)
+      dor-services-client (~> 1.0)
       dor-workflow-service (~> 2.0, >= 2.0.1)
       druid-tools (>= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
@@ -183,13 +185,17 @@ GEM
       retries
       rsolr (>= 1.0.3, < 3)
       ruby-cache (~> 0.3.0)
-      ruby-graphviz
       rubydora (~> 2.1)
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
+    dor-services-client (1.1.0)
+      activesupport (>= 4.2, < 6)
+      deprecation
+      faraday (~> 0.15)
+      nokogiri (~> 1.8)
     dor-workflow-service (2.3.0)
       activesupport (>= 3.2.1, < 6)
       confstruct (>= 0.2.7, < 2)
@@ -333,7 +339,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (5.1.0)
     netrc (0.11.0)
-    nokogiri (1.10.0)
+    nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     nokogiri-happymapper (0.8.0)
       nokogiri (~> 1.5)
@@ -445,7 +451,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-cache (0.3.0)
-    ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.0)
     rubydora (2.1.0)
       activemodel (>= 4.2.10)
@@ -548,7 +553,7 @@ DEPENDENCIES
   devise (~> 4.0)
   devise-remote-user (~> 1.0)
   dlss-capistrano
-  dor-services (~> 5.31)
+  dor-services (~> 6.1)
   dor-workflow-service
   dynamic_form
   equivalent-xml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (6.1.12)
+    dor-services (6.1.13)
       active-fedora (>= 8.7.0, < 9)
       activesupport (>= 4.2.10, < 6.0.0)
       confstruct (~> 0.2.7)
@@ -191,7 +191,7 @@ GEM
       stanford-mods-normalizer (~> 0.1)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
-    dor-services-client (1.1.0)
+    dor-services-client (1.1.1)
       activesupport (>= 4.2, < 6)
       deprecation
       faraday (~> 0.15)
@@ -554,6 +554,7 @@ DEPENDENCIES
   devise-remote-user (~> 1.0)
   dlss-capistrano
   dor-services (~> 6.1)
+  dor-services-client (~> 1.1)
   dor-workflow-service
   dynamic_form
   equivalent-xml

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ A Hydra application enabling deposit of digital objects into the Stanford
 Digital Repository for preservation and access.
 
 ## Setting up your environment
+
 ### System Requirements
+
 1. Install Docker
-
 2. Install Ruby 2.5.3
-
 
 ## Run the servers
 
 ```
-docker-compose up
+docker-compose up -d
 ```
 
 
@@ -47,6 +47,8 @@ ROLES=dlss:hydrus-app-administrators REMOTE_USER=archivist1@stanford.edu rails s
 * Solr - [http://localhost:8984/solr](http://localhost:8984/solr)
 
 ## Running tests
+
+To run the test suite, invoke `rake` from the Hydrus app root. Note that the docker containers need to be running already for this work.
 
 ```bash
 $ rake # Runs all tests.

--- a/app/models/hydrus/admin_policy_object.rb
+++ b/app/models/hydrus/admin_policy_object.rb
@@ -81,8 +81,8 @@ class Hydrus::AdminPolicyObject < Dor::AdminPolicyObject
     # Create the object, with the correct model.
     dconf = Dor::Config.hydrus
     args = [user, 'adminPolicy', dconf.ur_apo_druid]
-    apo  = Hydrus::GenericObject.register_dor_object(*args)
-    apo  = Hydrus::AdminPolicyObject.find(apo.pid)
+    response = Hydrus::GenericObject.register_dor_object(*args)
+    apo = Hydrus::AdminPolicyObject.find(response[:pid])
     apo.remove_relationship :has_model, 'info:fedora/afmodel:Dor_AdminPolicyObject'
     apo.assert_content_model
     # Add minimal descMetadata with a title.

--- a/app/models/hydrus/admin_policy_object.rb
+++ b/app/models/hydrus/admin_policy_object.rb
@@ -95,8 +95,6 @@ class Hydrus::AdminPolicyObject < Dor::AdminPolicyObject
     %w[sdr:developer sdr:service-manager sdr:metadata-staff].each do |group|
       rmd.add_group_with_role(group, 'dor-apo-manager')
     end
-    # Create defaultObjectRights datastream ... by mentioning it.
-    apo.defaultObjectRights.content_will_change!
     # Add the references agreement to the APO's RELS-EXT.
     apo.add_relationship(:references_agreement, 'info:fedora/druid:mc322hh4254')
     # Save and return.

--- a/app/models/hydrus/collection.rb
+++ b/app/models/hydrus/collection.rb
@@ -112,9 +112,9 @@ class Hydrus::Collection < Dor::Collection
     # Make sure user can create collections.
     cannot_do(:create) unless Hydrus::Authorizable.can_create_collections(user)
     # Create the object, with the correct model.
-    apo     = Hydrus::AdminPolicyObject.create(user)
-    dor_obj = Hydrus::GenericObject.register_dor_object(user, 'collection', apo.pid)
-    coll    = Hydrus::Collection.find(dor_obj.pid)
+    apo      = Hydrus::AdminPolicyObject.create(user)
+    response = Hydrus::GenericObject.register_dor_object(user, 'collection', apo.pid)
+    coll     = Hydrus::Collection.find(response[:pid])
     coll.remove_relationship :has_model, 'info:fedora/afmodel:Dor_Collection'
     coll.assert_content_model
     # Set the item_type, and add some Hydrus-specific info to identityMetadata.

--- a/app/models/hydrus/collection.rb
+++ b/app/models/hydrus/collection.rb
@@ -266,7 +266,7 @@ class Hydrus::Collection < Dor::Collection
     apo.identityMetadata.objectLabel = apt
     apo.title                        = apt
     apo.label                        = apt
-    apo.datastreams['DC'].content    = apo.generate_dublin_core.to_s
+    apo.datastreams['DC'].content    = Dor::DublinCoreService.new(apo).to_xml
     identityMetadata.objectLabel     = t
     self.label                       = t
   end

--- a/app/models/hydrus/generic_object.rb
+++ b/app/models/hydrus/generic_object.rb
@@ -294,7 +294,7 @@ class Hydrus::GenericObject < Dor::Item
   # Registers an object in Dor, and returns it.
   def self.register_dor_object(*args)
     params = self.dor_registration_params(*args)
-    Dor::RegistrationService.register_object(params)
+    Dor::Services::Client.objects.register(params: params)
   end
 
   # Returns a hash of info needed to register a Dor object.
@@ -302,9 +302,9 @@ class Hydrus::GenericObject < Dor::Item
     {
       object_type: obj_typ,
       admin_policy: apo_pid,
-      source_id: { 'Hydrus' => "#{obj_typ}-#{user_string}-#{HyTime.now_datetime_full}" },
+      source_id: "Hydrus:#{obj_typ}-#{user_string}-#{HyTime.now_datetime_full}",
       label: 'Hydrus',
-      tags: [Settings.hydrus.project_tag],
+      tag: [Settings.hydrus.project_tag],
       initiate_workflow: [Dor::Config.hydrus.app_workflow],
     }
   end

--- a/app/models/hydrus/rights_metadata_ds.rb
+++ b/app/models/hydrus/rights_metadata_ds.rb
@@ -67,6 +67,14 @@ class Hydrus::RightsMetadataDS < ActiveFedora::OmDatastream
     remove_nodes_by_xpath(q)
   end
 
+  # Hydrus uses customized rights metadata, but also uses models that include
+  # Dor::Editable. In dor-services 6.x, these methods moved out of the
+  # Dor::Editable module and moved into a datastream which Hydrus does not use.
+  # Stub out these methods to get the test suite running
+  [:default_rights, :use_license].each do |missing_method_name|
+    define_method(missing_method_name) {}
+  end
+
   def self.xml_template
     Nokogiri::XML::Builder.new do |xml|
       xml.rightsMetadata {

--- a/app/services/item_service.rb
+++ b/app/services/item_service.rb
@@ -40,7 +40,7 @@ class ItemService
   # @return [Hydrus::Item]
   def build_item(item_type)
     dor_item = Hydrus::GenericObject.register_dor_object(user, 'item', collection.apo_pid)
-    Hydrus::Item.find(dor_item.pid).tap do |item|
+    Hydrus::Item.find(dor_item[:pid]).tap do |item|
       item.remove_relationship :has_model, 'info:fedora/afmodel:Dor_Item'
       item.assert_content_model
       # Set the item_type, and add some Hydrus-specific info to identityMetadata.

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,19 @@ module Hydrus
     config.assets.version = '1.0'
 
     config.exceptions_app = self.routes
+
+    # Added to align w/ Rails upgrades and to silence a deprecation warning:
+    #
+    # DEPRECATION WARNING: Currently, Active Record suppresses errors raised
+    # within `after_rollback`/`after_commit` callbacks and only print them to
+    # the logs. In the next version, these errors will no longer be suppressed.
+    # Instead, the errors will propagate normally just like in other Active
+    # Record callbacks.
+    #
+    # You can opt into the new behavior and remove this warning by setting:
+    #
+    # config.active_record.raise_in_transactional_callbacks = true
+    config.active_record.raise_in_transactional_callbacks = true
   end
 end
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -50,7 +50,12 @@ Dor.configure do
     timeout Settings.workflow.timeout
   end
 
-  dor_services.url Settings.dor_services.url
+  dor_services do
+    url Settings.dor_services.url
+    user Settings.dor_services.user
+    pass Settings.dor_services.pass
+  end
+
   solr.url Settings.solr.url
   sdr.url Settings.sdr.url
 

--- a/config/initializers/dor_services_client.rb
+++ b/config/initializers/dor_services_client.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Configure dor-services-client to use the dor-services URL
+Dor::Services::Client.configure(url: Settings.dor_services.url,
+                                username: Settings.dor_services.user,
+                                password: Settings.dor_services.pass)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,7 +18,9 @@ workflow:
   url: 'https://workflow.example.com/workflow'
 
 dor_services:
-  url: 'https://user:password@dor-services.example.com'
+  url: 'http://localhost:3003'
+  username: 'user'
+  password: 'password'
 
 stacks:
   document_cache_storage_root: ~

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,8 +19,8 @@ workflow:
 
 dor_services:
   url: 'http://localhost:3003'
-  username: 'user'
-  password: 'password'
+  user: 'user'
+  pass: 'password'
 
 stacks:
   document_cache_storage_root: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,14 @@ services:
     image: suldlss/workflow-server:latest
     ports:
       - 3001:3000
+
+  dor-services-app:
+    image: suldlss/dor-services-app:latest
+    ports:
+      - 3003:3000
+    environment:
+      SOLR_URL: http://solr:8983/solr/hydrus_test
+      SETTINGS__SOLRIZER_URL: http://solr:8983/solr/hydrus_test
+      SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
+      SETTINGS__SURI__URL: http://suri:3000
+      SETTINGS__WORKFLOW_URL: http://workflow:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,8 @@ services:
     ports:
       - 3003:3000
     environment:
-      SOLR_URL: http://solr:8983/solr/hydrus_test
-      SETTINGS__SOLRIZER_URL: http://solr:8983/solr/hydrus_test
+      SOLR_URL: http://solr:8983/solr/hydrus-test
+      SETTINGS__SOLRIZER_URL: http://solr:8983/solr/hydrus-test
       SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
       SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000

--- a/spec/features/contact_spec.rb
+++ b/spec/features/contact_spec.rb
@@ -9,7 +9,7 @@ describe('Contact page', type: :request, integration: true) do
     @message_textarea  = 'textarea#message'
     @message           = 'Hello, this is is cool.'
     @send_button_text  = 'Send'
-    HydrusMailer.stub_chain(:contact_message, :deliver_now)
+    allow(HydrusMailer).to receive_message_chain(:contact_message, :deliver_now)
   end
 
   it 'shows the full form and then generate an email when a user fills in the contact form when not logged in' do

--- a/spec/features/models/admin_policy_object_spec.rb
+++ b/spec/features/models/admin_policy_object_spec.rb
@@ -16,8 +16,6 @@ describe(Hydrus::AdminPolicyObject, type: :feature, integration: true) do
     expect(apo.roleMetadata).to_not be_new
     expect(apo.roleMetadata.collection_manager.to_a).to include user
     expect(apo.roleMetadata.collection_depositor.to_a).to include user
-
-    expect(apo.defaultObjectRights).to_not be_new
     expect(apo.relationships(:references_agreement)).to include 'info:fedora/druid:mc322hh4254'
   end
 end

--- a/spec/models/hydrus/collection_spec.rb
+++ b/spec/models/hydrus/collection_spec.rb
@@ -70,7 +70,7 @@ describe Hydrus::Collection, type: :model do
       }
       tests.each do |meth, predicate|
         allow(@hc).to receive(predicate).and_return(false)
-        expect { @hc.send(meth) }.to raise_error
+        expect { @hc.send(meth) }.to raise_error(RuntimeError)
       end
     end
   end

--- a/spec/models/hydrus/generic_object_spec.rb
+++ b/spec/models/hydrus/generic_object_spec.rb
@@ -77,8 +77,7 @@ describe Hydrus::GenericObject, type: :model do
     it 'should be able to exercise register_dor_object(), using stubbed call to Dor' do
       args = %w(whobar item somePID)
       drp = Hydrus::GenericObject.dor_registration_params(*args)
-      expectation = expect(Dor::RegistrationService).to receive(:register_object)
-      expectation.with(hash_including(*drp.keys))
+      expect(Dor::Services::Client.objects).to receive(:register).with(params: hash_including(*drp.keys))
       Hydrus::GenericObject.register_dor_object(nil, nil, nil)
     end
   end

--- a/spec/support/rubydora_transactions_monkeypatch.rb
+++ b/spec/support/rubydora_transactions_monkeypatch.rb
@@ -32,7 +32,6 @@ class Rubydora::Transaction
           repository.ingest(pid: p, file: foxml)
           $fixture_solr_cache ||= {}
           $fixture_solr_cache[p] ||= begin
-            puts " indexing and caching #{p}"
             ActiveFedora::Base.find(p, cast: true).to_solr
           end
           solr.add $fixture_solr_cache[p]


### PR DESCRIPTION
Fixes #228 

Also:
* Configure TravisCI build to use docker-compose instead of recreating it
* Add dor-services-app to the docker-compose config
* Upgrade dor-services to 6.1.x 
* Work around underlying changes to Dor::Editable
* Bump to latest dor-services-client and dor-services to pick up new patches (needed because of bugs discovered doing this work)
* Remove deprecation warnings and use client for opening new versions