### PR TITLE
Give a workflow an id

### DIFF
--- a/config/assemblyWF_hydrus.xml
+++ b/config/assemblyWF_hydrus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="assemblyWF">
   <process name="start-assembly"        priority="80" status="completed" lifecycle="pipelined"/>
   <process name="jp2-create"            priority="80" status="skipped"/>
   <process name="checksum-compute"      priority="80" status="waiting"/>


### PR DESCRIPTION
This aligns Hydrus with the workflows that are retrieved from dor-services-app
Fixes #255 