### PR TITLE
Add a database for the workflow service to the docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ config/environments/*.local.yml
 
 spec/examples.txt
 script/test/
+
+# The docker volume for the workflow database
+postgres-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,31 @@ services:
     ports:
       - 3002:3000
 
+  db:
+    image: postgres
+     # No ports shared externally, so that this doesn't conflict with the postgres
+     # server that TravisCI starts up.
+     # ports:
+     #   - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=sekret
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+
   workflow:
     image: suldlss/workflow-server:latest
+    environment:
+      - RAILS_LOG_TO_STDOUT=true
+      - DATABASE_NAME=workflow-server
+      - DATABASE_USERNAME=postgres
+      - DATABASE_PASSWORD=sekret
+      - DATABASE_HOSTNAME=db
+      - DATABASE_PORT=5432
+      - SECRET_KEY_BASE="${SECRET_KEY_BASE}"
+      - SETTINGS__DOR_SERVICES__URL=http://dor-services-app:3000
+      - SETTINGS__ENABLE_STOMP=false
+    depends_on:
+      - db
     ports:
       - 3001:3000
 

--- a/spec/fixtures/workflow_xml/druid_oo000oo0000.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0000.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0001.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0001.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0002.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0002.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0003.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0003.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0004.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0004.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0005.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0005.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="waiting"/>
   <process name="approve" status="waiting"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0006.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0006.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0007.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0007.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0008.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0008.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0009.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0009.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0010.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0010.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0011.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0011.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0012.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0012.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>

--- a/spec/fixtures/workflow_xml/druid_oo000oo0013.xml
+++ b/spec/fixtures/workflow_xml/druid_oo000oo0013.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<workflow>
+<workflow id="hydrusAssemblyWF">
   <process name="start-deposit" status="completed" lifecycle="registered"/>
   <process name="submit" status="completed"/>
   <process name="approve" status="completed"/>


### PR DESCRIPTION
This is necessary because the workflow server image had been updated to require a database.
We also turn off the STOMP notifications.