### PR TITLE
Require hydrus to avoid a NoMethodError

### DIFF
--- a/app/mailers/hydrus_mailer.rb
+++ b/app/mailers/hydrus_mailer.rb
@@ -1,3 +1,5 @@
+require 'hydrus' # the fixture_pids
+
 class HydrusMailer < ActionMailer::Base
   helper ApplicationHelper
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module Hydrus
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{config.root}/lib #{config.root}/lib/validators)
+    config.eager_load_paths += %W(#{config.root}/lib #{config.root}/lib/validators)
   end
 end
 


### PR DESCRIPTION
This is already required in the spec_helper, so it didn't show up
as a test failure.  Also switch to eager_load_paths for Rails 5

Fixes #287