### PR TITLE
fix issue with blank titles in collection list view

### DIFF
--- a/app/models/hydrus/collection.rb
+++ b/app/models/hydrus/collection.rb
@@ -93,7 +93,8 @@ class Hydrus::Collection < Dor::Collection
     items = []
     items_from_solr.each do |solr_doc|
       id = solr_doc['id']
-      title = self.class.object_title(solr_doc)
+      solr_title = self.class.object_title(solr_doc)
+      title = solr_title.blank? ? 'Untitled' : solr_title
       num_files = (get_num_files ? Hydrus::ObjectFile.where(pid: id).count : -1)
       status = self.class.array_to_single(solr_doc['object_status_ssim'])
       object_type = self.class.array_to_single(solr_doc['mods_typeOfResource_ssim'])


### PR DESCRIPTION
fixes #298 

note, there is a helper method to do this (https://github.com/sul-dlss/hydrus/blob/master/app/helpers/application_helper.rb#L96-L98), but it operates on fedora objects, not the hash structure that is now being used here 