### PR TITLE
Set anonymizeIP true for Google Analytics

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -164,6 +164,7 @@ module ApplicationHelper
           })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
           ga('create', '#{GOOGLE_ANALYTICS_CODE}', 'auto');
+          ga('set', 'anonymizeIp', true);
           ga('send', 'pageview');
 
         </script>


### PR DESCRIPTION
A friendly PR to anonymizeIP for sdr.stanford.edu as we do this throughout our public portfolio