### PR TITLE
Use token generated by containerized dor-services-app

### DIFF
--- a/config/initializers/dor_config.rb
+++ b/config/initializers/dor_config.rb
@@ -33,12 +33,6 @@ Dor.configure do
     timeout Settings.workflow.timeout
   end
 
-  dor_services do
-    url Settings.dor_services.url
-    user Settings.dor_services.user
-    pass Settings.dor_services.pass
-  end
-
   solr.url Settings.solr.url
 
   hydrus do

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -75,7 +75,7 @@ suri_url.userinfo = [Dor::Config.suri.user, Dor::Config.suri.pass].join(':')
 OkComputer::Registry.register 'suri_url', OkComputer::HttpCheck.new(suri_url.to_s)
 
 # dor-services-app
-about_url = Dor::Config.dor_services.url + '/v1/about'
+about_url = Settings.dor_services.url + '/v1/about'
 OkComputer::Registry.register 'dor_services_url', OkComputer::HttpCheck.new(about_url)
 
 # Local filesystem public/uploads -> shared/public/uploads -> /data/hydrus-files

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,9 +19,8 @@ workflow:
 
 dor_services:
   url: 'http://localhost:3003'
-  user: dor-service-user
-  pass: dor-service-password
-  token: 'secret-token'
+  # To generate the token: docker-compose run dor-services-app rake generate_token
+  token: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJIeWRydXMtVGVzdCJ9.vfo6tMpMhoSqlNaIeW1N0CZKDHbNo_ABHHfpVmIZoHc'
   token_header: 'X-Auth' # This has to match dor-services-app ApplicationController::TOKEN_HEADER
 
 stacks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,9 @@ services:
       - DATABASE_PORT=5432
       - SECRET_KEY_BASE="${SECRET_KEY_BASE}"
       - SETTINGS__DOR_SERVICES__URL=http://dor-services-app:3000
-      - SETTINGS__DOR_SERVICES__USERNAME=dor-service-user
-      - SETTINGS__DOR_SERVICES__PASSWORD=dor-service-password
+      # To generate the token: docker-compose run dor-services-app rake generate_token
+      - SETTINGS__DOR_SERVICES__TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJIeWRydXMtVGVzdCJ9.vfo6tMpMhoSqlNaIeW1N0CZKDHbNo_ABHHfpVmIZoHc
+      - SETTINGS__DOR_SERVICES__TOKEN_HEADER=X-Auth
       - SETTINGS__ENABLE_STOMP=false
       - SETTINGS__REDIS__HOSTNAME=redis
     depends_on:


### PR DESCRIPTION
Do this for consistency. See also the same approach in Argo: https://github.com/sul-dlss/argo/pull/1468