### PR TITLE
Dump poorly named and unnecessary hash arg when opening versions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -145,7 +145,7 @@ Metrics/BlockLength:
 # Offense count: 9
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 544
+  Max: 545
 
 # Offense count: 13
 Metrics/CyclomaticComplexity:

--- a/app/models/hydrus/item.rb
+++ b/app/models/hydrus/item.rb
@@ -6,6 +6,7 @@ class Hydrus::Item < Hydrus::GenericObject
   has_and_belongs_to_many :collections, property: :is_member_of_collection, class_name: 'Hydrus::Collection'
 
   REQUIRED_FIELDS = [:title, :abstract, :contact, :keywords, :version_description, :date_created]
+  DEFAULT_VERSION_SIGNIFICANCE = :major
 
   after_validation :strip_whitespace
   attr_accessor :dates
@@ -175,11 +176,11 @@ class Hydrus::Item < Hydrus::GenericObject
     self.initial_publish_time = publish_time if is_initial_version
 
     # Set some version metadata that the Hydrus app uses.
-    vers_md_upd_info = {}
-    vers_md_upd_info[:significance] = opts[:significance] || :major
-    vers_md_upd_info[:description] = opts[:description] || ''
+    version_options = {}
+    version_options[:significance] = opts[:significance] || DEFAULT_VERSION_SIGNIFICANCE
+    version_options[:description] = opts[:description] || ''
     # Use the dor-services-client to open a new version, passing along args needed by Hydrus
-    Dor::Services::Client.object(pid).version.open(assume_accessioned: should_treat_as_accessioned, vers_md_upd_info: vers_md_upd_info)
+    Dor::Services::Client.object(pid).version.open(assume_accessioned: should_treat_as_accessioned, **version_options)
     # Varying behavior: remediations vs ordinary user edits.
     if opts[:is_remediation]
       # Just log the event.

--- a/spec/models/hydrus/item_spec.rb
+++ b/spec/models/hydrus/item_spec.rb
@@ -1121,8 +1121,8 @@ RSpec.describe Hydrus::Item, type: :model do
     end
 
     context 'when it has been accessioned' do
+      let(:description) { 'Best version ever described!' }
       let(:object_client) { instance_double(Dor::Services::Client::Object) }
-
       let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, open: true) }
 
       before do
@@ -1136,8 +1136,10 @@ RSpec.describe Hydrus::Item, type: :model do
 
       it 'calls the client and sets prior_visibility to the old visibility value' do
         expect(item).to receive(:start_hydrus_wf)
-        item.open_new_version
-        expect(version_client).to have_received(:open)
+        item.open_new_version(description: description)
+        expect(version_client).to have_received(:open).with(assume_accessioned: true,
+                                                            significance: Hydrus::Item::DEFAULT_VERSION_SIGNIFICANCE,
+                                                            description: description)
         expect(item.prior_visibility).to eq 'stanford'
       end
     end


### PR DESCRIPTION
It has already been removed in dor-services-app: https://github.com/sul-dlss/dor-services-app/pull/349