### PR TITLE
Remove token_header keyword arg when configuring dor-services-client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,9 +128,9 @@ GEM
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
     chronic (0.10.2)
-    cocina-models (0.1.0)
-      dry-struct
-      dry-types
+    cocina-models (0.1.2)
+      dry-struct (~> 1.0)
+      dry-types (~> 1.1)
       zeitwerk (~> 2.1)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -198,7 +198,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (2.5.0)
+    dor-services-client (2.6.2)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.1.0)
       faraday (~> 0.15)

--- a/config/initializers/dor_services_client.rb
+++ b/config/initializers/dor_services_client.rb
@@ -2,5 +2,4 @@
 
 # Configure dor-services-client to use the dor-services URL
 Dor::Services::Client.configure(url: Settings.dor_services.url,
-                                token: Settings.dor_services.token,
-                                token_header: Settings.dor_services.token_header)
+                                token: Settings.dor_services.token)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,7 +21,6 @@ dor_services:
   url: 'http://localhost:3003'
   # To generate the token: docker-compose run dor-services-app rake generate_token
   token: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJIeWRydXMtVGVzdCJ9.vfo6tMpMhoSqlNaIeW1N0CZKDHbNo_ABHHfpVmIZoHc'
-  token_header: 'X-Auth' # This has to match dor-services-app ApplicationController::TOKEN_HEADER
 
 stacks:
   document_cache_storage_root: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       - SETTINGS__DOR_SERVICES__URL=http://dor-services-app:3000
       # To generate the token: docker-compose run dor-services-app rake generate_token
       - SETTINGS__DOR_SERVICES__TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJIeWRydXMtVGVzdCJ9.vfo6tMpMhoSqlNaIeW1N0CZKDHbNo_ABHHfpVmIZoHc
-      - SETTINGS__DOR_SERVICES__TOKEN_HEADER=X-Auth
       - SETTINGS__ENABLE_STOMP=false
       - SETTINGS__REDIS__HOSTNAME=redis
     depends_on:


### PR DESCRIPTION
This is no longer required, and in fact can break the client if the header value (from shared_configs) is unset. This is what broke the workflow service connection to dor-services-app.