### PR TITLE
tell simplecov it's a rails app

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,10 @@
-# for test coverage
 require 'coveralls'
 require 'simplecov'
-# Coveralls.wear!('rails')
-# SimpleCov.start 'rails'
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
                                                                  SimpleCov::Formatter::HTMLFormatter,
                                                                  Coveralls::SimpleCov::Formatter
                                                                ])
-SimpleCov.start do
+SimpleCov.start :rails do
   add_filter 'spec'
   add_filter 'vendor'
 end


### PR DESCRIPTION
## Why was this change made?

Telling simplecov it's a Rails app means it will give more accurate stats on code coverage.

## Was the API documentation (openapi.json) updated?

N/A
