### PR TITLE
Use a non deprecated workflow update method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'assembly-objectfile', '~> 1.5'
 # or we'll get a superclass mismatch for Hydrus::Item
 gem 'dor-services', '~> 7.2', require: false
 gem 'dor-services-client', '~> 2.0'
+gem 'dor-workflow-client', '~> 3.9'
 gem 'rubydora', '~> 2.1'
 gem 'bagit', '~> 0.4'
 gem 'blacklight', '~> 6.19'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.6.0)
+    dor-workflow-client (3.9.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)
@@ -326,7 +326,7 @@ GEM
     mini_exiftool (2.9.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.12.0)
     moab-versioning (4.2.2)
       confstruct
       druid-tools (>= 1.0.0)
@@ -580,6 +580,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-services (~> 7.2)
   dor-services-client (~> 2.0)
+  dor-workflow-client (~> 3.9)
   dynamic_form
   equivalent-xml
   factory_bot_rails

--- a/app/models/hydrus/processable.rb
+++ b/app/models/hydrus/processable.rb
@@ -16,7 +16,10 @@ module Hydrus::Processable
   # Takes the name of a step in the Hydrus workflow.
   # Calls the workflow service to mark that step as completed.
   def update_workflow_status(step, status)
-    workflow_client.update_workflow_status(REPO, pid, Dor::Config.hydrus.app_workflow, step, status)
+    workflow_client.update_status(druid: pid,
+                                  workflow: Dor::Config.hydrus.app_workflow,
+                                  process: step,
+                                  status: status)
     workflows_content_is_stale
   end
 

--- a/spec/features/models/item_spec.rb
+++ b/spec/features/models/item_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Hydrus::Item, type: :feature, integration: true do
       instance_double(Dor::Workflow::Client,
                       all_workflows_xml: '',
                       milestones: [],
-                      update_workflow_status: nil,
+                      update_status: nil,
                       create_workflow_by_name: nil)
     end
     before do
@@ -92,10 +92,14 @@ RSpec.describe Hydrus::Item, type: :feature, integration: true do
       allow(hi).to receive(:should_start_assembly_wf).and_return(true)
       allow(hi).to receive(:is_assemblable).and_return(true)
       hi.do_publish()
-      expect(wfs).to have_received(:update_workflow_status).with('dor', hi.pid,
-                                                                 'hydrusAssemblyWF', 'approve', 'completed')
-      expect(wfs).to have_received(:update_workflow_status).with('dor', hi.pid,
-                                                                 'hydrusAssemblyWF', 'start-assembly', 'completed')
+      expect(wfs).to have_received(:update_status).with(druid: hi.pid,
+                                                        workflow: 'hydrusAssemblyWF',
+                                                        process: 'approve',
+                                                        status: 'completed')
+      expect(wfs).to have_received(:update_status).with(druid: hi.pid,
+                                                        workflow: 'hydrusAssemblyWF',
+                                                        process: 'start-assembly',
+                                                        status: 'completed')
       expect(wfs).to have_received(:create_workflow_by_name).with(hi.pid, 'assemblyWF', version: '1')
     end
   end

--- a/spec/models/hydrus/processable_spec.rb
+++ b/spec/models/hydrus/processable_spec.rb
@@ -8,14 +8,17 @@ RSpec.describe Hydrus::Processable, type: :model do
 
   describe 'complete_workflow_step()' do
     let(:wfs) { instance_double(Dor::Workflow::Client) }
+    let(:step) { 'submit' }
+
     before do
       allow(Dor::Config.workflow).to receive(:client).and_return(wfs)
     end
 
     it 'can exercise the method, stubbing out call to WF service' do
-      step = 'submit'
-      args = ['dor', @go.pid, 'hydrusAssemblyWF', step, 'completed']
-      expect(wfs).to receive(:update_workflow_status).with(*args)
+      expect(wfs).to receive(:update_status).with(druid: @go.pid,
+                                                  workflow: 'hydrusAssemblyWF',
+                                                  process: step,
+                                                  status: 'completed')
       allow(@go).to receive_message_chain(:workflows, :workflow_step_is_done).and_return(false)
       expect(@go).to receive(:workflows_content_is_stale)
       @go.complete_workflow_step(step)


### PR DESCRIPTION
This prevents the workflow service from logging deprecation notices in honeybadger.

## Why was this change made?

Deprecation errors logged in honeybadger: https://app.honeybadger.io/projects/58890/faults/54851492

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a