### PR TITLE
Avoid using the deprecated SearchService.solr method

### DIFF
--- a/app/controllers/hydrus_solr_controller.rb
+++ b/app/controllers/hydrus_solr_controller.rb
@@ -81,7 +81,7 @@ class HydrusSolrController < ApplicationController
 
   # Private method to return the application's SOLR connection.
   def solr
-    Dor::SearchService.solr
+    ActiveFedora.solr.conn
   end
 
   # Private method to return the logger for the SOLR reindexer.

--- a/lib/tasks/fixtures.rake
+++ b/lib/tasks/fixtures.rake
@@ -39,7 +39,7 @@ namespace :hydrus do
     unless obj.nil?
       puts "Reindexing #{pid} in solr"
       solr_doc = obj.to_solr
-      Dor::SearchService.solr.add(solr_doc, add_attributes: { commitWithin: 1000 })
+      ActiveFedora.solr.conn.add(solr_doc, add_attributes: { commitWithin: 1000 })
     else
       puts "#{pid} not found"
     end
@@ -57,8 +57,8 @@ namespace :hydrus do
       all_pids.each do |pid|
         puts "Deleteing #{pid}"
         Dor::Config.fedora.client["objects/#{pid}"].delete
-        Dor::SearchService.solr.delete_by_id(pid)
-        Dor::SearchService.solr.commit
+        ActiveFedora.solr.conn.delete_by_id(pid)
+        ActiveFedora.solr.conn.commit
       end
     end
   end

--- a/lib/tasks/hydrus.rake
+++ b/lib/tasks/hydrus.rake
@@ -40,7 +40,7 @@ namespace :hydrus do
     item.save
 
     # index into solr
-    solr = Dor::SearchService.solr
+    solr = ActiveFedora.solr.conn
     solr_doc = item.to_solr
     solr.add(solr_doc, add_attributes: { commitWithin: 5000 })
   end
@@ -49,14 +49,14 @@ namespace :hydrus do
   task index_all_workflows: :environment do
     # get all workflow objects using risearch (sparql on fedora) since we don't have a direct connection to argo solr
     model_type = "<#{Dor::WorkflowObject.to_class_uri}>"
-    solr = Dor::SearchService.solr
+    solr = ActiveFedora.solr.conn
     pids = Dor::SearchService.risearch 'select $object from <#ri> where $object ' "<fedora-model:hasModel> #{model_type}", { limit: nil }
     pids.each { |pid| solr.add(Dor.find(pid).to_solr, add_attributes: { commitWithin: 5000 }) } # index into hydrus solr
   end
 
   desc 'Reindex all hydrus collections and items into hydrus solr'
   task reindex_all_hydrus_objects: :environment do
-    solr = Dor::SearchService.solr
+    solr = ActiveFedora.solr.conn
     collection_pids = Hydrus::Collection.all_hydrus_collections
     total_collections = collection_pids.size
     puts "Found #{total_collections} hydrus collections.  Started re-index at #{Time.now}"

--- a/spec/controllers/hydrus_solr_controller_spec.rb
+++ b/spec/controllers/hydrus_solr_controller_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 # Note: other behavior is exercised in integration tests.
 
-describe HydrusSolrController, type: :controller do
+RSpec.describe HydrusSolrController, type: :controller do
   describe 'reindex()' do
-    it 'should respond with 404 if object is not in Fedora' do
+    it 'responds with 404 if object is not in Fedora' do
       bogus_pid = 'druid:BLAH'
       allow(ActiveFedora::Base).to receive(:find).and_return(nil)
       get :reindex, params: { id: bogus_pid }
@@ -12,7 +12,7 @@ describe HydrusSolrController, type: :controller do
       expect(response.body).to include('failed to find object')
     end
 
-    it 'should skip non-Hydrus objects' do
+    it 'skips non-Hydrus objects' do
       some_pid = 'druid:oo000oo9999'
       allow(ActiveFedora::Base).to receive(:find).and_return(Object.new)
       get :reindex, params: { id: some_pid }
@@ -20,16 +20,16 @@ describe HydrusSolrController, type: :controller do
       expect(response.body).to include('skipped')
     end
 
-    it 'should index Hydrus objects' do
+    it 'indexes Hydrus objects' do
       allow(ActiveFedora::Base).to receive(:find).and_return(instance_double(Hydrus::Item, tags: ['Project : Hydrus'], to_solr: { id: 'x' }))
-      expect(Dor::SearchService.solr).to receive(:add).with({ id: 'x' }, add_attributes: { commitWithin: 5000 }).and_return(true)
+      expect(ActiveFedora.solr.conn).to receive(:add).with({ id: 'x' }, add_attributes: { commitWithin: 5000 }).and_return(true)
       get :reindex, params: { id: 'druid:oo000oo9999' }
       expect(response.status).to eq(200)
     end
 
-    it 'should index Hydrus objects tagged with our project prefix' do
+    it 'indexes Hydrus objects tagged with our project prefix' do
       allow(ActiveFedora::Base).to receive(:find).and_return(instance_double(Hydrus::Item, tags: ['Project : Hydrus : IR : data'], to_solr: { id: 'x' }))
-      expect(Dor::SearchService.solr).to receive(:add).with({ id: 'x' }, add_attributes: { commitWithin: 5000 }).and_return(true)
+      expect(ActiveFedora.solr.conn).to receive(:add).with({ id: 'x' }, add_attributes: { commitWithin: 5000 }).and_return(true)
       get :reindex, params: { id: 'druid:oo000oo9999' }
       expect(response.status).to eq(200)
     end

--- a/spec/features/hydrus_solr_controller_spec.rb
+++ b/spec/features/hydrus_solr_controller_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 describe(HydrusSolrController, type: :feature, integration: true) do
   describe '#delete_from_index' do
     it 'removes items from solr' do
-      expect(Dor::SearchService.solr).to receive(:delete_by_id).with('x')
+      expect(ActiveFedora.solr.conn).to receive(:delete_by_id).with('x')
       visit '/hydrus_solr/delete_from_index/x'
     end
   end
 
   describe '#reindex' do
     it 'indexes an item into solr' do
-      expect(Dor::SearchService.solr).to receive(:add).with(hash_including(id: 'druid:oo000oo0001'), anything)
+      expect(ActiveFedora.solr.conn).to receive(:add).with(hash_including(id: 'druid:oo000oo0001'), anything)
       visit '/hydrus_solr/reindex/druid:oo000oo0001'
     end
   end


### PR DESCRIPTION
## Why was this change made?
The SearchService.solr is deprecated and should not be used.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a