### PR TITLE
Update to the latest mysql gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,9 +62,7 @@ group :development do
 end
 
 group :production do
-  # Rails 4.2.10 only supports mysql2 < 0.5
-  # See https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L3
-  gem 'mysql2', '~> 0.4.5'
+  gem 'mysql2', '~> 0.5.0'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,7 +340,7 @@ GEM
       nom-xml (~> 1.0)
     msgpack (1.3.1)
     multipart-post (2.1.1)
-    mysql2 (0.4.10)
+    mysql2 (0.5.3)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
@@ -589,7 +589,7 @@ DEPENDENCIES
   launchy
   letter_opener
   listen (>= 3.0.5, < 3.2)
-  mysql2 (~> 0.4.5)
+  mysql2 (~> 0.5.0)
   okcomputer
   pry
   rails (~> 5.2)


### PR DESCRIPTION


## Why was this change made?
Previously was pinned to 0.4 for rails 4.2, but we've since upgrade to rails 5.2


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
