### PR TITLE
re-pin mysql2 to a version we can deploy successfully on the current VM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,11 @@ group :development do
 end
 
 group :production do
-  gem 'mysql2', '~> 0.5.0'
+  # pinning because the latest mysql2 gem prevents successful deployment (a native extension compilation
+  # error is raised).  jcoyne suspects that the newer gem version requires a newer version of glibc than
+  # is on the VM, and that provisioning a newer VM with a newer version of MySQL (and its newer glibc
+  # requirement) would solve this dependency issue and allow use of the latest gem.
+  gem 'mysql2', '~> 0.4.10'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,7 +340,7 @@ GEM
       nom-xml (~> 1.0)
     msgpack (1.3.1)
     multipart-post (2.1.1)
-    mysql2 (0.5.3)
+    mysql2 (0.4.10)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
@@ -589,7 +589,7 @@ DEPENDENCIES
   launchy
   letter_opener
   listen (>= 3.0.5, < 3.2)
-  mysql2 (~> 0.5.0)
+  mysql2 (~> 0.4.10)
   okcomputer
   pry
   rails (~> 5.2)
@@ -609,4 +609,4 @@ DEPENDENCIES
   whenever (~> 0.9)
 
 BUNDLED WITH
-   2.1.1
+   2.1.4


### PR DESCRIPTION
see comment in `Gemfile` for explanation.  before this fix, attempting to deploy to stage resulted in an error, noted in a comment below.

with the fix in this branch, deployment to stage succeeded.