### PR TITLE
set cron job to weekly and try to log output

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,5 @@
-every :day, at: '12:20am', roles: [:app] do
+set :output, 'log/cron.log'
+
+every :week, at: '12:20am', roles: [:app] do
   rake 'hydrus:cleanup_tmp'
 end


### PR DESCRIPTION
## Why was this change made?

our nightly cron job generates a bunch of noise to email, for starters, we could just do this weekly, and secondly, maybe logging it will suppress the email?

attempt to address #393 


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
