### PR TITLE
Update to the latest coffee-script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'okcomputer'
 gem 'bootsnap'
 gem 'sassc', '~> 2.0.1' # Pinning to 2.0 because 2.1 requires GLIBC 2.14 on deploy
 gem 'sass-rails',     '~> 5.0'
-gem 'coffee-rails',   '~> 4.2'
+gem 'coffee-rails',   '~> 5.0'
 gem 'uglifier', '>= 1.0.3'
 
 # gems only needed for particular environments

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,9 +133,9 @@ GEM
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
     coderay (1.1.2)
-    coffee-rails (4.2.2)
+    coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
+      railties (>= 5.2.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -580,7 +580,7 @@ DEPENDENCIES
   capybara (~> 2.18)
   carrierwave (~> 1.0)
   coderay
-  coffee-rails (~> 4.2)
+  coffee-rails (~> 5.0)
   config
   coveralls
   devise (~> 4.0)


### PR DESCRIPTION


## Why was this change made?
This should prevent one of the many Gem::Specification#rubyforge_project= deprecations


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a