### PR TITLE
fix code coverage reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem 'sqlite3', '~> 1.3.13'
   gem 'rspec-rails', '~> 3.1'
   gem 'capybara', '~> 2.18'
-  gem 'simplecov'
+  gem 'simplecov', '~> 0.17.1', require: false # 0.18 breaks reporting to coveralls
   gem 'coveralls'
   gem 'equivalent-xml'
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
       rails (>= 4.2, < 6)
       rsolr (>= 1.0.6, < 3)
       twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
-    bootsnap (1.4.5)
+    bootsnap (1.4.6)
       msgpack (~> 1.0)
     bootstrap-datepicker-rails (1.9.0.1)
       railties (>= 3.0)
@@ -372,7 +372,7 @@ GEM
       solrizer (~> 3.3)
     orm_adapter (0.5.0)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.0.3)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     pry (0.12.2)
@@ -497,10 +497,11 @@ GEM
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
-    simplecov (0.18.3)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     solrizer (3.4.1)
       activesupport
       daemons
@@ -611,7 +612,7 @@ DEPENDENCIES
   rubydora (~> 2.1)
   sass-rails (~> 5.0)
   sassc (~> 2.0.1)
-  simplecov
+  simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.3.13)


### PR DESCRIPTION
## Why was this change made?

To get fresh coverage data with every PR (again).

This PR reverts simplecov to 0.17 to get coverage data reported. Some other dependency updates came along for the ride.

The most recent build to get coverage data was Jan 27.

![image](https://user-images.githubusercontent.com/96775/75491242-7efaea00-596a-11ea-8239-c372daccbf35.png)

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a

## Does this change affect how this application integrates with other services?

n/a

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
