### PR TITLE
Guard against an empty REMOTE_USER header

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ require 'devise_remote_user'
 
 DeviseRemoteUser.configure do |config|
   config.env_key = lambda do |env|
-    if env['REMOTE_USER']
+    if env['REMOTE_USER'].present?
       env['REMOTE_USER']
     elsif Rails.env.development? && ENV['REMOTE_USER']
       ENV['REMOTE_USER']


### PR DESCRIPTION
## Why was this change made?

Newly upgraded Centos 7/Apache 2.4/Shib ??  machines seem to pass through empty REMOTE_USER headers instead of omitting  the header altogether.
