### PR TITLE
Truncate Fedora 3 label

### DIFF
--- a/app/models/hydrus/item.rb
+++ b/app/models/hydrus/item.rb
@@ -110,7 +110,8 @@ class Hydrus::Item < Hydrus::GenericObject
     # Set label and title.
     t = title()
     identityMetadata.objectLabel = t
-    self.label = t
+    # Fedora 3 can only accept labels up to 255 characters, so trim them
+    self.label = t.truncate(255, separator: /\s/)
     datastreams['DC'].title = [t]
     # Update object status and advance workflow.
     self.object_status = 'published'


### PR DESCRIPTION
## Why was this change made?
Fedora rejects updates where the label is longer than 255 characters.

Fixes #430 


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

none

