### PR TITLE
Remove deprecated dor-services config

### DIFF
--- a/config/initializers/dor_config.rb
+++ b/config/initializers/dor_config.rb
@@ -35,7 +35,6 @@ Dor.configure do
 
   stacks do
     document_cache_host Settings.stacks.document_cache_host
-    local_document_cache_root Settings.stacks.local_document_cache_root
     local_workspace_root Settings.stacks.local_workspace_root
     local_stacks_root Settings.stacks.local_stacks_root
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,7 +21,6 @@ stacks:
   document_cache_host: ~
   local_stacks_root: ~
   local_workspace_root: ~
-  local_document_cache_root: ~
 
 solr:
   url: 'https://solr.example.com/solr/collection'


### PR DESCRIPTION
## Why was this change made?

This removes a deprecation warning that displays in testing.

## How was this change tested?

Running the test suite

## Which documentation and/or configurations were updated?

none

