### PR TITLE
Pass a version when deleting the workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'assembly-objectfile', '~> 1.5'
 # or we'll get a superclass mismatch for Hydrus::Item
 gem 'dor-services', '~> 8.0', require: false
 gem 'dor-services-client', '~> 6.0'
-gem 'dor-workflow-client', '~> 3.9'
+gem 'dor-workflow-client', '~> 3.22'
 gem 'rubydora', '~> 2.1'
 gem 'bagit', '~> 0.4'
 gem 'blacklight', '~> 6.19'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.21.0)
+    dor-workflow-client (3.22.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (>= 0.9.2, < 2.0)
@@ -601,7 +601,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-services (~> 8.0)
   dor-services-client (~> 6.0)
-  dor-workflow-client (~> 3.9)
+  dor-workflow-client (~> 3.22)
   dynamic_form
   equivalent-xml
   factory_bot_rails

--- a/app/models/hydrus/processable.rb
+++ b/app/models/hydrus/processable.rb
@@ -24,7 +24,7 @@ module Hydrus::Processable
 
   # Deletes an objects hydrus workflow.
   def delete_hydrus_workflow
-    workflow_client.delete_workflow(REPO, pid, Settings.hydrus.app_workflow)
+    workflow_client.delete_workflow(REPO, pid, Settings.hydrus.app_workflow, version: current_version)
   end
 
   # Generates the object's contentMetadata, finalizes the hydrusAssemblyWF


### PR DESCRIPTION
#91  Why was this change made?

Not passing a version is deprecated and will cause an error when support for that is removed from workflow-server-rails

## How was this change tested?

Test suite.


## Which documentation and/or configurations were updated?

none

