### PR TITLE
the new vms have ruby 2.7.1 deployed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,4 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 rvm:
-  - 2.5.3 # deployed
-  - 2.7.1
+  - 2.7.1 # deployed


### PR DESCRIPTION
## Why was this change made?

No longer using ruby 2.5.3 (new vms have ruby 2.7.1)

## How was this change tested?

testing with app running 2.7.1 on new sul-hydrus-stage

## Which documentation and/or configurations were updated?

none


