### PR TITLE
swap out coveralls for code climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,17 @@ before_script:
   - until curl --silent -XGET --fail -o /dev/null http://localhost:3002; do printf '.'; sleep 1; done
   - until curl --silent -XGET --fail -o /dev/null http://localhost:3003/status; do printf '.'; sleep 1; done
   - until curl --silent -XGET --fail -o /dev/null http://localhost:3004; do printf '.'; sleep 1; done
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+    - CC_TEST_REPORTER_ID=3cdbe95bc010f6d3a02b14a9e421d6e85e1626d9b105c372c303ed8585cc7e3f
 
 rvm:
   - 2.7.1 # deployed

--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,7 @@ group :development, :test do
   gem 'sqlite3', '~> 1.3.13'
   gem 'rspec-rails', '~> 3.1'
   gem 'capybara', '~> 2.18'
-  gem 'simplecov', '~> 0.17.1', require: false # 0.18 breaks reporting to coveralls
-  gem 'coveralls'
+  gem 'simplecov', '~> 0.17.1', require: false # 0.18 breaks reporting to CodeClimate
   gem 'equivalent-xml'
   gem 'awesome_print'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,12 +154,6 @@ GEM
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    coveralls (0.7.1)
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      term-ansicolor
-      thor
     crass (1.0.6)
     daemons (1.3.1)
     deep_merge (1.2.1)
@@ -351,7 +345,6 @@ GEM
       nokogiri (>= 1.6.6)
       nom-xml (~> 1.0)
     msgpack (1.3.3)
-    multi_json (1.15.0)
     multipart-post (2.1.1)
     mysql2 (0.4.10)
     net-scp (3.0.0)
@@ -538,15 +531,10 @@ GEM
     stanford-mods-normalizer (0.1.0)
       nokogiri (~> 1.8)
     stomp (1.4.9)
-    sync (0.5.0)
     temple (0.8.2)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.25.0)
-      sync
     twitter-typeahead-rails (0.11.1.pre.corejavascript)
       actionpack (>= 3.1)
       jquery-rails
@@ -595,7 +583,6 @@ DEPENDENCIES
   coderay
   coffee-rails (~> 5.0)
   config
-  coveralls
   devise (~> 4.0)
   devise-remote-user (~> 1.0)
   dlss-capistrano

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hydrus
 [![Build Status](https://travis-ci.org/sul-dlss/hydrus.svg?branch=master)](https://travis-ci.org/sul-dlss/hydrus)
-[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/hydrus/badge.svg)](https://coveralls.io/github/sul-dlss/hydrus)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/4f81c285af8b8889c9f4/test_coverage)](https://codeclimate.com/github/sul-dlss/hydrus/test_coverage)
 
 ## Overview
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,5 @@
-require 'coveralls'
 require 'simplecov'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-                                                                 SimpleCov::Formatter::HTMLFormatter,
-                                                                 Coveralls::SimpleCov::Formatter
-                                                               ])
+
 SimpleCov.start :rails do
   add_filter 'spec'
   add_filter 'vendor'


### PR DESCRIPTION
## Why was this change made?

coveralls integration with github is flaky, this swaps it out for codeclimate


## How was this change tested?

by confirming the integration works here


## Which documentation and/or configurations were updated?

README updated with new badge


