### PR TITLE
Reference images using helpers

### DIFF
--- a/app/assets/stylesheets/styles.css.scss
+++ b/app/assets/stylesheets/styles.css.scss
@@ -651,7 +651,7 @@ li.errors
 	margin: 2px 0;
 	border: 1px inset #446;
 	border-radius: 5px;
-	background: #eee url("/assets/progress.png") 100% 0 repeat-y;
+	background: #eee url(asset-path("progress.png")) 100% 0 repeat-y;
 }
 
 #file-progress p.failed

--- a/app/assets/stylesheets/sul_chrome/sul_chrome_base.scss
+++ b/app/assets/stylesheets/sul_chrome/sul_chrome_base.scss
@@ -5,7 +5,7 @@ $baseLineHeight: 18px;
 @import "bootstrap/mixins/border-radius";
 
 body {
-	background: url("/assets/body.png") repeat scroll 0 0 transparent;
+	background: url(asset-path("body.png")) repeat scroll 0 0 transparent;
 	font-family: Lucida Grande,Verdana,Arial,sans-serif;
 	line-height: 1.5em;
 }
@@ -30,13 +30,13 @@ a:hover.btn {
 	background-color: #990000;
 }
 #sul-wrapper {
-	background: url("/assets/wrapper.png") repeat-x scroll 0 0 transparent;
+	background: url(asset-path("wrapper.png")) repeat-x scroll 0 0 transparent;
 	text-align: center;
 	padding-top: 15px;
 }
 
 #container {
-	background: url("/assets/top-container.png") repeat-x scroll 0 0 #FFFFFF;
+	background: url(asset-path("top-container.png")) repeat-x scroll 0 0 #FFFFFF;
   	border-radius: 3px 3px 3px 3px;
   	border-top: 1px solid #FFFFFF;
 	margin: 0 auto;
@@ -101,7 +101,7 @@ $ribbon-offset-vertical: 8px; // height of shadow
   margin: 0 -54px 30px -54px;
   text-shadow: 0 1px rgba(0,0,0,.8);
   background: #651006;
-  background: url("/assets/bg-nav.png") repeat-x;
+  background: url(asset-path("bg-nav.png")) repeat-x;
   box-shadow: rgba(0,0,0,.3) 0 1px 0;
   &:before, &:after { // ribbon edge styling
     content: '';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="no-js">
 <head>
   <title><%= h(@page_title || "") %></title>
-  <link rel="shortcut icon" href="/assets/favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="<%= image_path('favicon.ico') %>" type="image/x-icon" />
   <%= stylesheet_link_tag    "application", :media => "all" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Fixes #454

## Why was this change made?

To restore image assets.

## How was this change tested?

Deployed to stage and confirmed working.

## Which documentation and/or configurations were updated?

None

