### PR TITLE
Rename sul-purl-test to sul-purl-stage

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,7 +10,7 @@ hydrus:
   project_tag: 'Project : Hydrus'
 
 purl:
-  base_url: 'https://sul-purl-test.stanford.edu/'
+  base_url: 'https://sul-purl-stage.stanford.edu/'
 
 dor_services:
   url: 'http://localhost:3003'


### PR DESCRIPTION
sul-purl-test is being decommissioned for naming consistency. It will be
aliased to sul-purl-stage, but for visibility we should probably rename
it everywhere.