### PR TITLE
Avoid NoMethodError in datastreams controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,10 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def contextual_id
+    @contextual_id ||= params.select { |k, _| k.to_s =~ /^hydrus_.*_id/ }.to_unsafe_hash.each_value.first
+  end
+
   def current_user
     super.tap do |cur_user|
       break unless cur_user

--- a/app/controllers/datastreams_controller.rb
+++ b/app/controllers/datastreams_controller.rb
@@ -8,15 +8,9 @@ class DatastreamsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    pid = contextual_id()
+    pid = contextual_id
     authorize! :view_datastreams, pid
     @fobj = ActiveFedora::Base.find(pid, cast: true)
     @fobj.current_user = current_user
-  end
-
-  protected
-
-  def contextual_id
-    @contextual_id ||= params.select { |k, v| k.to_s =~ /^hydrus_.*_id/ }.each_value.first
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,10 +12,4 @@ class EventsController < ApplicationController
     @fobj.current_user = current_user
     authorize! :read, @fobj
   end
-
-  protected
-
-  def contextual_id
-    @contextual_id ||= params.select { |k, v| k.to_s =~ /^hydrus_.*_id/ }.to_unsafe_hash.each_value.first
-  end
 end

--- a/spec/controllers/datastreams_controller_spec.rb
+++ b/spec/controllers/datastreams_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe DatastreamsController, type: :controller do
+  before do
+    @ability = Object.new
+    @ability.extend(CanCan::Ability)
+    allow(controller).to receive_messages(current_ability: @ability)
+  end
+
+  it 'requires login' do
+    get :index, params: { hydrus_collection_id: '1234' }
+    expect(flash[:alert]).to eq('You need to sign in or sign up before continuing.')
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  context 'as an authenticated user' do
+    let(:user) { create :archivist1 }
+
+    before do
+      sign_in(user)
+    end
+
+    it "restricts access to users who shouldn't be able to view datastreams" do
+      mock_coll = double('HydrusCollection', hydrus_class_to_s: 'Collection')
+      expect(mock_coll).not_to receive(:"current_user=")
+      expect(ActiveFedora::Base).not_to receive(:find)
+      @ability.cannot :view_datastreams, '1234'
+
+      get :index, params: { hydrus_collection_id: '1234' }
+
+      expect(flash[:alert]).to eq('You are not authorized to access this page.')
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'assigns the given object for the given ID as the fobj instance variable' do
+      mock_coll = double('HydrusCollection', hydrus_class_to_s: 'Collection')
+      expect(mock_coll).to receive(:"current_user=")
+      allow(ActiveFedora::Base).to receive(:find).and_return(mock_coll)
+      @ability.can :view_datastreams, '1234'
+
+      get :index, params: { hydrus_collection_id: '1234' }
+
+      expect(response).to be_successful
+      expect(assigns(:fobj)).to eq(mock_coll)
+    end
+  end
+end


### PR DESCRIPTION
Connects to https://app.honeybadger.io/projects/49897/faults/48659064

## Why was this change made?

This bug, which is not triggered very often, was caused by the upgrade to Rails 5. We adjusted the call  in the events controller but not in the datastreams controller to avoid calling a method that is no longer defined on `ActionController::Parameters`.

As part of this work, reduce duplication of code by moving a now-identical method into `ApplicationController`.


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

