### PR TITLE
spec_helper: allow single spec file to default to document format

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --color
---format progress

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -160,6 +160,16 @@ RSpec.configure do |config|
   # rspec-rails.
   config.infer_base_class_for_anonymous_controllers = false
 
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+  end
+
   # Restore prior state of Fedora repository.
   config.around(:each) do |example|
     ActiveFedora::Base.connection_for_pid(0).transaction do |t|


### PR DESCRIPTION
## Why was this change made?

So when running a single spec file, it defaults to document format.  The default spec format is progress, so removing that from the .rspec file will have no effect, and keeping it in meant the change in spec_helper had no effect.

## How was this change tested?

empirically - used it locally.

## Which documentation and/or configurations were updated?



