### PR TITLE
default collection objects to have world access

### DIFF
--- a/app/models/hydrus/generic_object.rb
+++ b/app/models/hydrus/generic_object.rb
@@ -312,7 +312,7 @@ class Hydrus::GenericObject < Dor::Item
 
       params[:administrative][:partOfProject] = 'Hydrus' unless obj_typ == 'adminPolicy'
       params[:identification] = { sourceId: "Hydrus:#{obj_typ}-#{user_string}-#{HyTime.now_datetime_full}" } if obj_typ == 'item'
-      params[:access] = {} if obj_typ == 'collection'
+      params[:access] = { access: 'world' } if obj_typ == 'collection'
     end.with_indifferent_access
   end
 

--- a/spec/models/hydrus/generic_object_spec.rb
+++ b/spec/models/hydrus/generic_object_spec.rb
@@ -67,13 +67,21 @@ describe Hydrus::GenericObject, type: :model do
     let(:args) { %w(whobar item druid:bc123df4567) }
 
     it 'returns the expected hash' do
-      puts dor_registration_params
       expect(dor_registration_params[:type]).to eq('http://cocina.sul.stanford.edu/models/object.jsonld')
       expect(dor_registration_params[:label]).to eq('Hydrus')
       expect(dor_registration_params[:version]).to eq(1)
       expect(dor_registration_params[:administrative][:hasAdminPolicy]).to eq('druid:bc123df4567')
       expect(dor_registration_params[:administrative][:partOfProject]).to eq('Hydrus')
       expect(dor_registration_params[:identification][:sourceId]).to start_with('Hydrus:item-whobar-')
+      expect(dor_registration_params[:access]).to eq nil
+    end
+
+    context 'when collection object' do
+      let(:args) { %w(whobar collection druid:ab123de4567) }
+
+      it 'access is "world"' do
+        expect(dor_registration_params[:access][:access]).to eq('world')
+      end
     end
   end
 


### PR DESCRIPTION
~~Hold until it's clear these are the correct default permissions.~~ Andrew signed off in slack

## Why was this change made?

Fixes #478 - new Hydrus collections have been created with incorrect default permissions for some time now.

## How was this change tested?

on stage; also wrote a test

## Which documentation and/or configurations were updated?



