### PR TITLE
Deploy hydrus to qa

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,4 @@
+server 'sul-hydrus-qa.stanford.edu', user: 'hydrus', roles: %w{web db app}
+
+Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'production'


### PR DESCRIPTION
## Why was this change made?

To let cap deploy to the -qa machine

## How was this change tested?

By deploying this branch

## Which documentation and/or configurations were updated?

DevOpsDocs PR forthcoming

