### PR TITLE
update dor-services-client to 6.16

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'assembly-objectfile', '~> 1.5'
 # We don't require this by default, because we need it to load after hydrus models
 # or we'll get a superclass mismatch for Hydrus::Item
 gem 'dor-services', '~> 8.0', require: false
-gem 'dor-services-client', '~> 6.15'
+gem 'dor-services-client', '~> 6.16'
 gem 'dor-workflow-client', '~> 3.22'
 gem 'rubydora', '~> 2.1'
 gem 'bagit', '~> 0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
     chronic (0.10.2)
-    cocina-models (0.43.0)
+    cocina-models (0.44.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -197,9 +197,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (6.15.0)
+    dor-services-client (6.16.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.43.0)
+      cocina-models (~> 0.44.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -589,7 +589,7 @@ DEPENDENCIES
   devise-remote-user (~> 1.0)
   dlss-capistrano
   dor-services (~> 8.0)
-  dor-services-client (~> 6.15)
+  dor-services-client (~> 6.16)
   dor-workflow-client (~> 3.22)
   dynamic_form
   equivalent-xml


### PR DESCRIPTION
## Why was this change made?

to keep in sync with tiny cocina-models change for a dor-services-app mapping ticket.

## How was this change tested?



## Which documentation and/or configurations were updated?



